### PR TITLE
fix: incorrect asset type for data streams, which resulted in the Kinesis data stream not being deleted after a sync

### DIFF
--- a/docs/connectors/aws.mdx
+++ b/docs/connectors/aws.mdx
@@ -204,9 +204,9 @@ The AWS resources that Cyscale can handle are listed in the tables below, along 
 | SSOUser             | 0             |
 
 | Integration         | # of Controls |
-| ------------------- | ------------- |
+|---------------------|---------------|
 | API                 | 0             |
-| DataStream          | 1             |
+| KinesisDataStream   | 1             |
 | EventBridgeRule     | 0             |
 | EventBridgeSchedule | 0             |
 | MQBroker            | 0             |


### PR DESCRIPTION
Refs: CYS-4268